### PR TITLE
Update workshop6.md actions/cache version to v4

### DIFF
--- a/workshop/workshop6.md
+++ b/workshop/workshop6.md
@@ -84,7 +84,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-nodemodules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
v2 deprecated, will fail on run

See: https://github.com/Arabasta/bitcoin-order-app/actions/runs/14141412611/job/39623227749

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/4ebe726e-6b4c-4bc8-b05f-67fe0f72e0f0" />
